### PR TITLE
Fix repo provenance URLs

### DIFF
--- a/research-skills-library/repo-skills/accelerate/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/accelerate/references/repo-provenance.md
@@ -12,7 +12,7 @@ Read this before deciding whether this skill is current for a checkout of Huggin
   "generated_at_utc": "2026-06-21T00:00:00Z",
   "repository": {
     "name": "accelerate",
-    "remote_url": "omitted-private-or-unknown",
+    "remote_url": "https://github.com/huggingface/accelerate",
     "vcs": "git",
     "branch": "main",
     "tag": null,

--- a/research-skills-library/repo-skills/agilerl/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/agilerl/references/repo-provenance.md
@@ -8,7 +8,7 @@
 - Commit: `3f2a3210efa9186ed3f893b0ee1d27ffe524e698`
 - Branch: `main`
 - Exact tag: none detected
-- Remote URL: omitted-private-or-unknown
+- Remote URL: https://github.com/AgileRL/AgileRL
 - Working tree state at generation: dirty due to generated `skills/` outputs in this checkout
 
 ## Evidence Paths

--- a/research-skills-library/repo-skills/albumentations/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/albumentations/references/repo-provenance.md
@@ -7,7 +7,7 @@
 - Git commit: `66212d77a44927a29d6a0e81621d3c27afbd929c`
 - Git branch: `main`
 - Exact tag: none detected
-- Remote URL: omitted-private-or-unknown
+- Remote URL: https://github.com/albumentations-team/albumentations
 - Working tree state at generation: dirty because this DisCo run added generated skill and review artifacts under `skills/`.
 
 ## Evidence paths

--- a/research-skills-library/repo-skills/alphafold3/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/alphafold3/references/repo-provenance.md
@@ -13,7 +13,7 @@ This skill was generated from AlphaFold 3 repository evidence and live package i
 - Working tree state at baseline: dirty because this generated `skills/` directory was added; no pre-existing tracked source modifications were detected.
 - Package distribution: `alphafold3`
 - Package version verified during inspection: `3.0.3`
-- Remote URL: omitted-private-or-unknown
+- Remote URL: https://github.com/google-deepmind/alphafold3
 
 ## Evidence Paths
 

--- a/research-skills-library/repo-skills/apache-airflow/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/apache-airflow/references/repo-provenance.md
@@ -14,7 +14,7 @@ Read this before deciding whether this skill is current for an Apache Airflow ch
   "generated_at_utc": "2026-06-23T00:00:00Z",
   "repository": {
     "name": "apache-airflow",
-    "remote_url": "omitted-private-or-unknown",
+    "remote_url": "https://github.com/apache/airflow",
     "vcs": "git",
     "branch": "main",
     "tag": null,

--- a/research-skills-library/repo-skills/autogen/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/autogen/references/repo-provenance.md
@@ -8,7 +8,7 @@ schema: `disco.repo-provenance.v1`
 - Branch: `main`
 - Exact tag: `none`
 - Working tree state: dirty; generated skill artifacts are untracked under `skills/`
-- Remote URL: omitted-private-or-unknown
+- Remote URL: https://github.com/microsoft/autogen
 - Package versions verified for inspection: `autogen-core==0.7.5`, `autogen-agentchat==0.7.5`, `autogen-ext==0.7.5`, `pyautogen==0.10.0`, `agbench==0.0.1a1`
 
 ## Evidence Paths

--- a/research-skills-library/repo-skills/axolotl/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/axolotl/references/repo-provenance.md
@@ -12,7 +12,7 @@ Read this before deciding whether this Axolotl repo skill is current for a check
   "generated_at_utc": "2026-06-22T00:00:00Z",
   "repository": {
     "name": "axolotl",
-    "remote_url": "omitted-private-or-unknown",
+    "remote_url": "https://github.com/axolotl-ai-cloud/axolotl",
     "vcs": "git",
     "branch": "main",
     "tag": null,

--- a/research-skills-library/repo-skills/bitsandbytes/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/bitsandbytes/references/repo-provenance.md
@@ -12,7 +12,7 @@ Read this before deciding whether this skill is current for a checkout of bitsan
   "generated_at_utc": "2026-06-21T00:00:00Z",
   "repository": {
     "name": "bitsandbytes",
-    "remote_url": "omitted-private-or-unknown",
+    "remote_url": "https://github.com/bitsandbytes-foundation/bitsandbytes",
     "vcs": "git",
     "branch": "agents/skill-bitsandbytes",
     "tag": "continuous-release_main",

--- a/research-skills-library/repo-skills/browser-use/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/browser-use/references/repo-provenance.md
@@ -12,7 +12,7 @@ Read this before deciding whether this skill is current for a Browser Use checko
   "generated_at_utc": "2026-06-21T00:00:00Z",
   "repository": {
     "name": "browser-use",
-    "remote_url": "omitted-private-or-unknown",
+    "remote_url": "https://github.com/browser-use/browser-use",
     "vcs": "git",
     "branch": "main",
     "tag": null,

--- a/research-skills-library/repo-skills/camel-ai/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/camel-ai/references/repo-provenance.md
@@ -1,7 +1,7 @@
 # Repo Provenance
 
 - Schema: `disco.repo-provenance.v1`
-- Source repository: CAMEL-AI local checkout; remote URL omitted-private-or-unknown.
+- Source repository: CAMEL-AI local checkout; remote URL: `https://github.com/camel-ai/camel`.
 - Source commit: `51ae9bb92be2b124927e9d9822210873e4b29c16`
 - Branch: `master`
 - Exact tag: none detected at generation commit.

--- a/research-skills-library/repo-skills/chemprop/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/chemprop/references/repo-provenance.md
@@ -10,7 +10,7 @@ schema: disco.repo-provenance.v1
 - Git branch: `main`
 - Exact tag: none recorded
 - Working tree state at generation: dirty because DisCo-generated `skills/` content was present or being created
-- Remote URL: omitted-private-or-unknown
+- Remote URL: https://github.com/chemprop/chemprop
 
 ## Evidence Paths
 

--- a/research-skills-library/repo-skills/clearml/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/clearml/references/repo-provenance.md
@@ -8,7 +8,7 @@
 - Source branch: `master`
 - Exact tag: none detected
 - Working tree state at generation: dirty because the new generated skill/artifact files were untracked under `skills/`; no pre-existing source-code modifications were reported before generation.
-- Remote URL: omitted-private-or-unknown
+- Remote URL: https://github.com/clearml/clearml
 
 ## Evidence Paths
 

--- a/research-skills-library/repo-skills/comfy-ui/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/comfy-ui/references/repo-provenance.md
@@ -10,7 +10,7 @@
 - Branch: `master`
 - Commit: `0d8b7510bdc5409f4a76c3191e122ddea50f4aa2`
 - Exact tag: none detected
-- Remote URL: omitted-private-or-unknown
+- Remote URL: https://github.com/comfyanonymous/ComfyUI
 - Working tree state at generation: dirty because DisCo-created files were present under `skills/`
 
 ## Evidence Paths

--- a/research-skills-library/repo-skills/dagster/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/dagster/references/repo-provenance.md
@@ -12,7 +12,7 @@ Read this before deciding whether this skill is current for a checkout of Dagste
   "generated_at_utc": "2026-06-21T00:00:00Z",
   "repository": {
     "name": "dagster",
-    "remote_url": "omitted-private-or-unknown",
+    "remote_url": "https://github.com/dagster-io/dagster",
     "vcs": "git",
     "branch": "master",
     "tag": null,

--- a/research-skills-library/repo-skills/dask/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/dask/references/repo-provenance.md
@@ -12,7 +12,7 @@ This skill was generated from repository evidence for the Dask Python package.
 | Commit | `c9d1df34ccba182ddf43c2dbe4315c4d9c8c44e1` |
 | Branch | `main` |
 | Exact tag | none detected |
-| Remote URL | omitted-private-or-unknown |
+| Remote URL | https://github.com/dask/dask |
 | Working tree state at generation | dirty: generated `skills/` tree was untracked during skill creation |
 | Package distribution | `dask` |
 | Package version observed during inspection | `0.0.post1+gc9d1df34c` |

--- a/research-skills-library/repo-skills/datasets/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/datasets/references/repo-provenance.md
@@ -5,7 +5,7 @@
 - Source commit: `06fcc085fcdd22fc5cc741954f6187dd879543b6`
 - Source branch: `main`
 - Exact tag: none detected
-- Remote URL: omitted-private-or-unknown
+- Remote URL: https://github.com/huggingface/datasets
 - Working tree state at generation: dirty because DisCo-generated files were added under `skills/`
 - Package version from metadata and installed inspection: `5.0.1.dev0`
 - Python support from package metadata: `>=3.10.0`

--- a/research-skills-library/repo-skills/deepchem/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/deepchem/references/repo-provenance.md
@@ -8,7 +8,7 @@ schema: `disco.repo-provenance.v1`
 - Commit: `046c8b84fdcbf7e1b72bbbbd07fa2502ff9b94dd`
 - Branch: `master`
 - Exact tag: none detected
-- Remote URL: omitted-private-or-unknown
+- Remote URL: https://github.com/deepchem/deepchem
 - Working tree state at generation: dirty because the generated `skills/` tree was added during this DisCo run
 - Package distribution version observed in inspection environment: `2.8.1.dev20260621163742`
 - Package import version observed from `deepchem.__version__`: `2.8.1.dev`

--- a/research-skills-library/repo-skills/deepmd-kit/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/deepmd-kit/references/repo-provenance.md
@@ -8,7 +8,7 @@ source:
   commit: b52c359ec6b6f6f34998e00f774c35d253cf09e5
   branch: master
   tag: null
-  remote_url: omitted-private-or-unknown
+  remote_url: https://github.com/deepmodeling/deepmd-kit
 working_tree:
   dirty: true
   note: Generated skill artifacts were present during provenance capture; source code evidence was otherwise read-only for this skill creation run.

--- a/research-skills-library/repo-skills/esm/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/esm/references/repo-provenance.md
@@ -9,7 +9,7 @@ This skill was generated from the ESM / fair-esm source repository.
 - Commit: `2b369911bb5b4b0dda914521b9475cad1656b2ac`
 - Exact tag: none detected
 - Working tree state at generation: dirty because generated DisCo output was present under `skills/`
-- Remote URL: omitted-private-or-unknown
+- Remote URL: https://github.com/facebookresearch/esm
 - Package distribution: `fair-esm`
 - Package version observed during inspection: `2.0.1`
 

--- a/research-skills-library/repo-skills/fastmri/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/fastmri/references/repo-provenance.md
@@ -12,7 +12,7 @@
 - Installed package version inspected: `0.1.dev1+g91f2df471`
 - Python requirement from package metadata: `>=3.8`
 - Working tree state at generation: dirty because generated `skills/` outputs were added; no source-code changes were detected before skill creation.
-- Remote URL: omitted-private-or-unknown
+- Remote URL: https://github.com/facebookresearch/fastMRI
 
 ## Evidence Paths
 

--- a/research-skills-library/repo-skills/feast/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/feast/references/repo-provenance.md
@@ -12,7 +12,7 @@ Read this before deciding whether this skill is current for a Feast checkout. If
   "generated_at_utc": "2026-06-21T00:00:00Z",
   "repository": {
     "name": "feast",
-    "remote_url": "omitted-private-or-unknown",
+    "remote_url": "https://github.com/feast-dev/feast",
     "vcs": "git",
     "branch": "master",
     "tag": null,

--- a/research-skills-library/repo-skills/flashrag/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/flashrag/references/repo-provenance.md
@@ -12,7 +12,7 @@ Read this before deciding whether this skill is current for a checkout of FlashR
   "generated_at_utc": "2026-06-21T00:00:00Z",
   "repository": {
     "name": "FlashRAG",
-    "remote_url": "omitted-private-or-unknown",
+    "remote_url": "https://github.com/RUC-NLPIR/FlashRAG",
     "vcs": "git",
     "branch": "main",
     "tag": null,

--- a/research-skills-library/repo-skills/haystack/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/haystack/references/repo-provenance.md
@@ -1,6 +1,7 @@
 # Repo Provenance
 
 - Repository: `deepset-ai/haystack`
+- Remote URL: `https://github.com/deepset-ai/haystack`
 - Commit: `75c51b683f07045460f377679bc491b4b9c0c044`
 - Branch: `main`
 - Package: `haystack-ai`

--- a/research-skills-library/repo-skills/kedro/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/kedro/references/repo-provenance.md
@@ -14,7 +14,7 @@ This repo skill was generated from a local Kedro checkout. It records source sta
 | git commit | `e69b22eb5a8679b784f9f9a6012d5de7c36d7c4b` |
 | git branch | `main` |
 | exact tag | none recorded |
-| remote URL | omitted-private-or-unknown |
+| remote URL | https://github.com/kedro-org/kedro |
 | dirty state at integration | dirty: generated `skills/` artifacts were present; no pre-existing source changes were recorded in the initial snapshot |
 
 ## Evidence Paths

--- a/research-skills-library/repo-skills/langchain/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/langchain/references/repo-provenance.md
@@ -6,7 +6,7 @@
 - commit: `9d14a5e06d98355e5c0eccd0736b961fbe419f87`
 - branch: `master`
 - exact tag: none
-- remote_url: omitted-private-or-unknown
+- remote_url: https://github.com/langchain-ai/langchain
 - dirty checkout: yes, generated `skills/` content was present at generation time
 
 ## Package Versions Observed from Metadata

--- a/research-skills-library/repo-skills/lightning/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/lightning/references/repo-provenance.md
@@ -5,7 +5,7 @@
 - Source branch: `master`
 - Exact tag: `none`
 - Package version from source: `2.6.2`
-- Remote URL: omitted-private-or-unknown
+- Remote URL: https://github.com/Lightning-AI/pytorch-lightning
 - Generated skill id: `lightning`
 - Generated from dirty checkout: yes
 

--- a/research-skills-library/repo-skills/litellm/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/litellm/references/repo-provenance.md
@@ -12,7 +12,7 @@ Read this before deciding whether this skill is current for a checkout of LiteLL
   "generated_at_utc": "2026-06-21T06:41:29Z",
   "repository": {
     "name": "litellm",
-    "remote_url": "omitted-private-or-unknown",
+    "remote_url": "https://github.com/BerriAI/litellm",
     "vcs": "git",
     "branch": "litellm_internal_staging",
     "tag": null,

--- a/research-skills-library/repo-skills/llama-index/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/llama-index/references/repo-provenance.md
@@ -6,7 +6,7 @@
 - Source commit: `9f66e8a649856524ef0ff081a23d58cd071b6ae4`
 - Source branch: `main`
 - Exact tag: none detected
-- Remote URL: omitted-private-or-unknown
+- Remote URL: https://github.com/run-llama/llama_index
 - Working tree at extraction start: clean; generated `skills/` artifacts were added afterward
 - Root package version from `pyproject.toml`: `llama-index==0.14.22`
 - Live inspected package: `llama-index-core==0.14.22`

--- a/research-skills-library/repo-skills/lmdeploy/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/lmdeploy/references/repo-provenance.md
@@ -12,7 +12,7 @@ Read this before deciding whether this skill is current for a checkout of LMDepl
   "generated_at_utc": "2026-06-22T16:30:00Z",
   "repository": {
     "name": "lmdeploy",
-    "remote_url": "omitted-private-or-unknown",
+    "remote_url": "https://github.com/InternLM/lmdeploy",
     "vcs": "git",
     "branch": "main",
     "tag": null,

--- a/research-skills-library/repo-skills/mdanalysis/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/mdanalysis/references/repo-provenance.md
@@ -7,7 +7,7 @@ This skill was generated from repository evidence for the MDAnalysis source tree
 ## Source Snapshot
 
 - Source repository: MDAnalysis/mdanalysis
-- Remote URL: omitted-private-or-unknown
+- Remote URL: https://github.com/MDAnalysis/mdanalysis
 - Branch: `develop`
 - Commit: `d25f074b7d9a24fbcd5ee9c6c9bd9751001949b7`
 - Exact tag: none detected

--- a/research-skills-library/repo-skills/mlflow/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/mlflow/references/repo-provenance.md
@@ -11,7 +11,7 @@ This file records the source evidence baseline used to generate the `mlflow` ski
 - Branch: `master`
 - Exact tag: none recorded
 - Working tree state at generation: dirty because the generated `skills/` artifact tree was untracked
-- Remote URL: omitted-private-or-unknown
+- Remote URL: https://github.com/mlflow/mlflow
 
 ## Evidence Paths
 

--- a/research-skills-library/repo-skills/mmdetection/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/mmdetection/references/repo-provenance.md
@@ -14,7 +14,7 @@ This skill was generated from MMDetection repository evidence and live package i
 | Git commit | `cfd5d3a985b0249de009b67d04f37263e11cdf3d` |
 | Exact tag | none detected |
 | Working tree state | clean at initial scope capture; generated `skills/` artifacts were added during skill creation |
-| Remote URL | omitted-private-or-unknown |
+| Remote URL | https://github.com/open-mmlab/mmdetection |
 
 ## Relative Evidence Paths
 

--- a/research-skills-library/repo-skills/openfe/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/openfe/references/repo-provenance.md
@@ -12,7 +12,7 @@ Read this before deciding whether this skill is current for a checkout of the re
   "generated_at_utc": "2026-06-29T17:38:56Z",
   "repository": {
     "name": "openfe",
-    "remote_url": "omitted-private-or-unknown",
+    "remote_url": "https://github.com/OpenFreeEnergy/openfe",
     "vcs": "git",
     "branch": "main",
     "tag": null,

--- a/research-skills-library/repo-skills/openhands/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/openhands/references/repo-provenance.md
@@ -12,7 +12,7 @@ Read this before deciding whether this skill is current for an OpenHands checkou
   "generated_at_utc": "2026-06-29T00:00:00Z",
   "repository": {
     "name": "OpenHands",
-    "remote_url": "omitted-private-or-unknown",
+    "remote_url": "https://github.com/OpenHands/OpenHands",
     "vcs": "git",
     "branch": "main",
     "tag": null,

--- a/research-skills-library/repo-skills/peft/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/peft/references/repo-provenance.md
@@ -1,6 +1,7 @@
 # Repo Provenance
 
 - Repository: `huggingface/peft`
+- Remote URL: `https://github.com/huggingface/peft`
 - Commit: `036abd27e464819e0a19ddaa26093c84d5943488`
 - Branch: `main`
 - Package/import: `peft`

--- a/research-skills-library/repo-skills/pillow/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/pillow/references/repo-provenance.md
@@ -12,7 +12,7 @@ This skill was generated from the Pillow repository snapshot below.
 | Git commit | `2d18dacf0b4a4c1ceab2f07f65394431a4c3428e` |
 | Branch | `main` |
 | Exact tag | none |
-| Remote URL | omitted-private-or-unknown |
+| Remote URL | https://github.com/python-pillow/Pillow |
 | Working tree state before skill generation | clean |
 | Working tree state after skill generation | generated untracked `skills/` review/runtime artifacts |
 

--- a/research-skills-library/repo-skills/protein-mpnn/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/protein-mpnn/references/repo-provenance.md
@@ -8,7 +8,7 @@
 - Commit: `8907e6671bfbfc92303b5f79c4b5e6ce47cdef57`
 - Exact tag: none detected
 - Working tree state at generation: dirty because the generated `skills/` tree was added
-- Remote URL: omitted-private-or-unknown
+- Remote URL: https://github.com/dauparas/ProteinMPNN
 - Package version: not declared; this is a script-style repository without `pyproject.toml`, `setup.py`, or distribution metadata
 
 ## Evidence Paths

--- a/research-skills-library/repo-skills/pyserini/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/pyserini/references/repo-provenance.md
@@ -12,7 +12,7 @@ Read this before deciding whether this skill is current for a checkout of Pyseri
   "generated_at_utc": "2026-06-22T18:58:58Z",
   "repository": {
     "name": "pyserini",
-    "remote_url": "omitted-private-or-unknown",
+    "remote_url": "https://github.com/castorini/pyserini",
     "vcs": "git",
     "branch": "master",
     "tag": null,

--- a/research-skills-library/repo-skills/ragatouille/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/ragatouille/references/repo-provenance.md
@@ -7,7 +7,7 @@
 - Commit: `e75b8a964a870dea886548f78da1900804749040`
 - Branch: `main`
 - Exact tag: none detected
-- Remote URL: omitted-private-or-unknown
+- Remote URL: https://github.com/AnswerDotAI/RAGatouille
 - Package distribution: `RAGatouille`
 - Package version: `0.0.9post2` in source and `0.0.9.post2` from installed distribution metadata
 - Skill generation state: generated from a dirty checkout because the new `skills/` tree was created during generation

--- a/research-skills-library/repo-skills/ray/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/ray/references/repo-provenance.md
@@ -14,7 +14,7 @@ This repo skill was generated from repository evidence for Ray and is intended t
 | Working tree state | dirty: generated `skills/` content present |
 | Source package version | `3.0.0.dev0` from `python/ray/_version.py` |
 | Installed inspection package | `ray` 2.55.1 used only for live API/CLI signature checks |
-| Remote URL | omitted-private-or-unknown |
+| Remote URL | https://github.com/ray-project/ray |
 
 The generated skill uses current source files and documentation for Ray 3.0.0.dev0 intent, packaging, submodule coverage, and provenance. A private installed Ray 2.55.1 environment was used only to verify stable public imports, selected signatures, optional-extra behavior, and CLI help surfaces. Local environment paths and Python executable paths are intentionally omitted.
 

--- a/research-skills-library/repo-skills/rdkit/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/rdkit/references/repo-provenance.md
@@ -10,7 +10,7 @@ This file is the refresh baseline for the generated `rdkit` skill.
 - Commit: `73ef78025c9a265e42b8c9578775de18b11f1829`
 - Branch: `master`
 - Exact tag: none detected
-- Remote URL: omitted-private-or-unknown
+- Remote URL: https://github.com/rdkit/rdkit
 - Source version variables from `CMakeLists.txt`: `RDKit_Year=2026`, `RDKit_Month=09`, `RDKit_Revision=1`, `RDKit_RevisionModifier=pre`, `RDKit_ABI=1`
 - Working tree state at generation: dirty because new DisCo output was created under `skills/`
 

--- a/research-skills-library/repo-skills/rfdiffusion/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/rfdiffusion/references/repo-provenance.md
@@ -12,7 +12,7 @@ Read this before deciding whether this skill is current for a checkout of RFdiff
   "generated_at_utc": "2026-06-21T00:00:00Z",
   "repository": {
     "name": "RFdiffusion",
-    "remote_url": "omitted-private-or-unknown",
+    "remote_url": "https://github.com/RosettaCommons/RFdiffusion",
     "vcs": "git",
     "branch": "main",
     "tag": null,

--- a/research-skills-library/repo-skills/schnetpack/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/schnetpack/references/repo-provenance.md
@@ -11,7 +11,7 @@ Generated skill id: `schnetpack`
 - Branch: `master`
 - Exact tag: none recorded
 - Package version: `2.2.0`
-- Remote URL: omitted-private-or-unknown
+- Remote URL: https://github.com/atomistic-machine-learning/schnetpack
 - Dirty state: the checkout contained newly generated `skills/` output during final provenance capture. No pre-existing source-code modifications were used as extraction evidence.
 
 ## Primary Evidence Paths

--- a/research-skills-library/repo-skills/scvi-tools/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/scvi-tools/references/repo-provenance.md
@@ -13,7 +13,7 @@ This skill was generated from repository evidence for `scvi-tools`.
 - Working tree state: dirty at generation time
 - Dirty summary: untracked `skills/` tree containing generated DisCo runtime and review/test artifacts
 - Package version: `1.4.3`
-- Remote URL: omitted-private-or-unknown
+- Remote URL: https://github.com/scverse/scvi-tools
 
 ## Evidence Paths
 

--- a/research-skills-library/repo-skills/segmentation-models-pytorch/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/segmentation-models-pytorch/references/repo-provenance.md
@@ -12,7 +12,7 @@ Read this before deciding whether this skill is current for a checkout of the re
   "generated_at_utc": "2026-06-30T00:00:00Z",
   "repository": {
     "name": "segmentation_models.pytorch",
-    "remote_url": "omitted-private-or-unknown",
+    "remote_url": "https://github.com/qubvel-org/segmentation_models.pytorch",
     "vcs": "git",
     "branch": "main",
     "tag": null,

--- a/research-skills-library/repo-skills/sglang/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/sglang/references/repo-provenance.md
@@ -1,6 +1,7 @@
 # Repo Provenance
 
 - Repository: `sgl-project/sglang`
+- Remote URL: `https://github.com/sgl-project/sglang`
 - Commit: `b4dda8b3ce8dcec52f96516da9593d51333782cf`
 - Branch: `main`
 - Package/import: `sglang`

--- a/research-skills-library/repo-skills/smolagents/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/smolagents/references/repo-provenance.md
@@ -11,7 +11,7 @@
 - Git branch: `main`
 - Exact tag: none detected
 - Working tree state: dirty at generation time because DisCo-generated `skills/` artifacts were being added during this run; no pre-existing source-code modifications were reported by the initial repository snapshot.
-- Remote URL: omitted-private-or-unknown
+- Remote URL: https://github.com/huggingface/smolagents
 
 ## Evidence Paths
 

--- a/research-skills-library/repo-skills/snakemake/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/snakemake/references/repo-provenance.md
@@ -15,7 +15,7 @@ This skill was generated from Snakemake repository evidence and installed-packag
 | Source commit | `3d933e63e8b51a520d65aac2d3f3b2c19b1b36fd` |
 | Source branch | `main` |
 | Exact tag | `v9.23.1` |
-| Remote URL | `omitted-private-or-unknown` |
+| Remote URL | `https://github.com/snakemake/snakemake` |
 | Working tree state | Dirty: untracked `skills/` generated artifacts were present during skill creation. |
 
 ## Evidence Paths

--- a/research-skills-library/repo-skills/squidpy/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/squidpy/references/repo-provenance.md
@@ -15,7 +15,7 @@ This skill was generated from a Squidpy source checkout and live package inspect
 | Working tree state | dirty: untracked `skills/` directory present |
 | Package distribution | `squidpy` |
 | Inspected package version | `0.1.dev1+g9f9d50028` |
-| Remote URL | omitted-private-or-unknown |
+| Remote URL | https://github.com/scverse/squidpy |
 
 ## Evidence Paths
 

--- a/research-skills-library/repo-skills/stable-baselines3/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/stable-baselines3/references/repo-provenance.md
@@ -12,7 +12,7 @@ Read this before deciding whether this skill is current for a checkout of Stable
   "generated_at_utc": "2026-06-21T00:00:00Z",
   "repository": {
     "name": "stable-baselines3",
-    "remote_url": "omitted-private-or-unknown",
+    "remote_url": "https://github.com/DLR-RM/stable-baselines3",
     "vcs": "git",
     "branch": "master",
     "tag": "v2.9.0",

--- a/research-skills-library/repo-skills/stable-diffusion-webui/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/stable-diffusion-webui/references/repo-provenance.md
@@ -7,7 +7,7 @@
 - Branch: `master`
 - Exact tag: `v1.10.1`
 - Package version: repository tag v1.10.1
-- Remote URL: omitted-private-or-unknown
+- Remote URL: https://github.com/AUTOMATIC1111/stable-diffusion-webui
 - Working tree state: dirty
 
 ## Dirty State Summary

--- a/research-skills-library/repo-skills/tevatron/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/tevatron/references/repo-provenance.md
@@ -14,7 +14,7 @@ Read this before deciding whether this Tevatron skill is current for a checkout.
 | Commit | `f0fc1e8b73ecda0075e69bed66ab72611413979e` |
 | Branch | `main` |
 | Exact tag | none detected |
-| Remote URL | omitted-private-or-unknown |
+| Remote URL | https://github.com/texttron/tevatron |
 | Package distribution | `tevatron` |
 | Package version | `0.0.1` |
 | Source layout | `src/tevatron` via `setup.py` |

--- a/research-skills-library/repo-skills/torchdrug/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/torchdrug/references/repo-provenance.md
@@ -12,7 +12,7 @@ Read this before deciding whether this skill is current for a checkout of TorchD
   "generated_at_utc": "2026-06-29T18:51:58Z",
   "repository": {
     "name": "torchdrug",
-    "remote_url": "omitted-private-or-unknown",
+    "remote_url": "https://github.com/DeepGraphLearning/torchdrug",
     "vcs": "git",
     "branch": "master",
     "tag": null,

--- a/research-skills-library/repo-skills/torchvision/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/torchvision/references/repo-provenance.md
@@ -11,7 +11,7 @@
 - Live inspection package version used for stable API signatures: `torchvision 0.27.1+cpu`
 - Dirty state at generation: dirty because the generated `skills/` directory was added during DisCo creation
 - Dirty paths summary: `skills/` untracked/generated
-- Remote URL: omitted-private-or-unknown
+- Remote URL: https://github.com/pytorch/vision
 
 ## Evidence Paths
 

--- a/research-skills-library/repo-skills/transformers/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/transformers/references/repo-provenance.md
@@ -12,7 +12,7 @@ This skill was generated from the Hugging Face Transformers repository state bel
 | Exact tag | none detected |
 | Package version | `5.13.0.dev0` |
 | Dirty state at generation | dirty: generated `skills/` artifacts were untracked during skill creation |
-| Remote URL | omitted-private-or-unknown |
+| Remote URL | https://github.com/huggingface/transformers |
 
 ## Evidence Paths
 

--- a/research-skills-library/repo-skills/trl/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/trl/references/repo-provenance.md
@@ -12,7 +12,7 @@ Read this before deciding whether this skill is current for a checkout of TRL. I
   "generated_at_utc": "2026-06-21T00:00:00Z",
   "repository": {
     "name": "trl",
-    "remote_url": "omitted-private-or-unknown",
+    "remote_url": "https://github.com/huggingface/trl",
     "vcs": "git",
     "branch": "main",
     "tag": null,

--- a/research-skills-library/repo-skills/ultralytics/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/ultralytics/references/repo-provenance.md
@@ -10,7 +10,7 @@
 - Source branch: `main`.
 - Exact tag: none detected at generation commit.
 - Working tree state at generation: dirty because `skills/` contained untracked generated/review artifacts.
-- Remote URL: omitted-private-or-unknown.
+- Remote URL: `https://github.com/ultralytics/ultralytics`
 - Package version used for live inspection: `8.4.72`.
 
 ## Evidence Paths

--- a/research-skills-library/repo-skills/unilm/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/unilm/references/repo-provenance.md
@@ -6,7 +6,7 @@
 - Source branch: `master`
 - Exact tag: none detected
 - Working tree state at generation: dirty because `skills/` review/runtime outputs were untracked
-- Remote URL: omitted-private-or-unknown
+- Remote URL: https://github.com/microsoft/unilm
 - Package/version facts: representative lightweight live inspection verified `adalm` distribution version `0.0` and import module `finetune`; `unilm-v1/src/setup.py` declares `pytorch_pretrained_bert` version `0.4.0`
 - Inspection environment: private research context only; no local executable, prefix, or cache paths are recorded in this public skill
 

--- a/research-skills-library/repo-skills/unsloth/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/unsloth/references/repo-provenance.md
@@ -10,7 +10,7 @@ Generated for the `unsloth` repository from a Git checkout.
 - Package distribution: `unsloth`
 - Package version observed during inspection: `2026.6.8`
 - Python requirement from package metadata: `>=3.9,<3.15`
-- Remote URL: omitted-private-or-unknown
+- Remote URL: https://github.com/unslothai/unsloth
 
 ## Working Tree State
 

--- a/research-skills-library/repo-skills/unstructured/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/unstructured/references/repo-provenance.md
@@ -12,7 +12,7 @@ This skill was generated from the Unstructured Python package repository.
 - Package distribution: `unstructured`
 - Package version: `0.23.1`
 - Working tree state: dirty because this generated `skills/` tree was added during skill creation.
-- Remote URL: omitted-private-or-unknown
+- Remote URL: https://github.com/Unstructured-IO/unstructured
 
 ## Evidence Paths
 

--- a/research-skills-library/repo-skills/verl/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/verl/references/repo-provenance.md
@@ -12,7 +12,7 @@ Read this before deciding whether this skill is current for a checkout of the re
   "generated_at_utc": "2026-06-21T00:00:00Z",
   "repository": {
     "name": "verl",
-    "remote_url": "omitted-private-or-unknown",
+    "remote_url": "https://github.com/volcengine/verl",
     "vcs": "git",
     "branch": "main",
     "tag": null,

--- a/research-skills-library/repo-skills/zenml/references/repo-provenance.md
+++ b/research-skills-library/repo-skills/zenml/references/repo-provenance.md
@@ -12,7 +12,7 @@ Read this before deciding whether this skill is current for a checkout of the Ze
   "generated_at_utc": "2026-06-30T00:00:00Z",
   "repository": {
     "name": "zenml",
-    "remote_url": "omitted-private-or-unknown",
+    "remote_url": "https://github.com/zenml-io/zenml",
     "vcs": "git",
     "branch": "main",
     "tag": null,


### PR DESCRIPTION
## Summary

This PR completes and validates the public upstream repository URLs recorded in the Research Skills Library provenance files.

- Replace 59 `omitted-private-or-unknown` placeholders with their public GitHub repository URLs.
- Add missing remote URLs for Haystack, PEFT, and SGLang.
- Validate all existing provenance URLs against the repository skills catalog.
- Preserve valid provenance formats such as `Remote URL`, `Source URL`, and `Source repository URL`.

## Validation

- Verified all 170 repository-skill directories against the catalog.
- Verified that all 170 provenance files contain the expected upstream repository URL.
- Verified that all provenance commits match the catalog commit SHAs.
- Verified that the documented skill counts match the actual `SKILL.md` files.
- Confirmed that no unresolved remote URL placeholders remain.
- Ran `git diff --check` successfully.

This is a metadata-only change and does not affect runtime behavior.