### PR TITLE
Fix snapshot traversal, validator link crash, Windows home expansion

### DIFF
--- a/cli/packages/coding-agent/UPSTREAM_MANIFEST.json
+++ b/cli/packages/coding-agent/UPSTREAM_MANIFEST.json
@@ -4425,7 +4425,7 @@
     },
     {
       "localPath": "packages/coding-agent/src/disco/import_meta_skill.test.ts",
-      "localSha256": "000cb787bd4d3a934291cf4532ee48307c4931a2680e7fb3c135f129c949c56e",
+      "localSha256": "1e70b42c8f94a0f7f4b00f70a792382051a75589740a35ce7b930450d664509b",
       "origin": "disco_owned"
     },
     {
@@ -4435,7 +4435,7 @@
     },
     {
       "localPath": "packages/coding-agent/src/disco/import_repo_skill.test.ts",
-      "localSha256": "5363f1446f31301b1691d6dbb6f190c48821916e721e8bcb2288eb60e22f5470",
+      "localSha256": "cd4ba56f6f417c74497d503b83568feda3fafa8996e7f1e310888cae6ee3a1de",
       "origin": "disco_owned"
     },
     {
@@ -4560,7 +4560,7 @@
     },
     {
       "localPath": "packages/coding-agent/src/disco/skills/design-meta-skill/scripts/validate_meta_skill.mjs",
-      "localSha256": "4bcbc1db75a7b512456454d46224c6005f45f5e0b114c8ba49c19cadeda10726",
+      "localSha256": "3a1b7f4f158dc6cf3b3122241b53e4eba55df34ce823a486aecff850683c2edd",
       "origin": "disco_owned"
     },
     {
@@ -4700,7 +4700,7 @@
     },
     {
       "localPath": "packages/coding-agent/src/disco/skills/prepare-paper-recovery-env/scripts/probe_runtime.py",
-      "localSha256": "86f05abe88479693d750d7f7af5f95dcd7d50258536f04269064095f7874c0f5",
+      "localSha256": "d1543bbd45b6b830709c9284c22edaeea040ae3f766b44bea55c1152fcfbebf9",
       "origin": "disco_owned"
     },
     {
@@ -4710,7 +4710,7 @@
     },
     {
       "localPath": "packages/coding-agent/src/disco/skills/prepare-paper-recovery-env/tests/test_probe_runtime.py",
-      "localSha256": "d2c98c39332760a453b1993e18265e426eb0d222d18ed67f466afbab871165d6",
+      "localSha256": "7fef285cf920a3fc05615ab552087f7bc9f598d1d721ba69fef333c586f0f23b",
       "origin": "disco_owned"
     },
     {
@@ -4835,7 +4835,7 @@
     },
     {
       "localPath": "packages/coding-agent/src/disco/skills/verify-repo-skill/scripts/import_repo_skill.mjs",
-      "localSha256": "154b03e936dafe0c7ae5f51ef17e7ec129b0a0c8570fbfeae2eb13fa7e2b5b1f",
+      "localSha256": "03813db99c155227e24c6e9ddd8af8a25f54c32eb56733a8db0596cb5604f8c4",
       "origin": "disco_owned"
     },
     {

--- a/cli/packages/coding-agent/src/disco/import_meta_skill.test.ts
+++ b/cli/packages/coding-agent/src/disco/import_meta_skill.test.ts
@@ -222,4 +222,24 @@ describe("import_meta_skill.mjs", () => {
 		expect(result.stderr).toContain("--already-locked requires DISCO_IMPORT_LOCK_PATH");
 		expect(existsSync(path.join(agentDir, "skills", "source-constructor"))).toBe(false);
 	});
+
+	it("reports an invalid encoded link instead of throwing", async () => {
+		const root = await mkdtemp(path.join(tmpdir(), "disco-meta-validate-"));
+		cleanupPaths.push(root);
+		const candidate = await writeCandidate(path.join(root, "draft"), "source-constructor", "v1");
+		const skillFile = path.join(candidate, "SKILL.md");
+		const content = await readFile(skillFile, "utf8");
+		await writeFile(skillFile, `${content}\nSee [x](foo%ZZbar.md).\n`, "utf8");
+
+		const validator = path.join(
+			process.cwd(),
+			"packages/coding-agent/src/disco/skills/design-meta-skill/scripts/validate_meta_skill.mjs",
+		);
+		const result = spawnSync(process.execPath, [validator, candidate, "--json"], { encoding: "utf8" });
+
+		expect(result.status).toBe(1);
+		const report = JSON.parse(result.stdout) as { valid: boolean; errors: string[] };
+		expect(report.valid).toBe(false);
+		expect(report.errors.join("\n")).toContain("invalid encoded Markdown link");
+	});
 });

--- a/cli/packages/coding-agent/src/disco/import_repo_skill.test.ts
+++ b/cli/packages/coding-agent/src/disco/import_repo_skill.test.ts
@@ -261,4 +261,9 @@ describe("import_repo_skill.mjs", () => {
 		const result = runImporter(path.join(root, "agent"), candidate);
 		expect(result.status, result.stderr).toBe(0);
 	});
+
+	it("uses Windows-compatible home expansion", async () => {
+		const content = await readFile(scriptPath, "utf8");
+		expect(content).toContain("[\\\\/]");
+	});
 });

--- a/cli/packages/coding-agent/src/disco/skills/design-meta-skill/scripts/validate_meta_skill.mjs
+++ b/cli/packages/coding-agent/src/disco/skills/design-meta-skill/scripts/validate_meta_skill.mjs
@@ -36,7 +36,14 @@ function validateLinks(root, filePath, body, errors) {
 	for (const match of body.matchAll(linkPattern)) {
 		const target = match[1]?.split("#", 1)[0];
 		if (!target || /^(?:https?:|mailto:)/.test(target)) continue;
-		const resolvedTarget = resolve(dirname(filePath), decodeURIComponent(target));
+		let decoded;
+		try {
+			decoded = decodeURIComponent(target);
+		} catch {
+			errors.push(`${filePath}: invalid encoded Markdown link: ${target}`);
+			continue;
+		}
+		const resolvedTarget = resolve(dirname(filePath), decoded);
 		const relativeTarget = relative(root, resolvedTarget);
 		if (relativeTarget === ".." || relativeTarget.startsWith(`..${sep}`) || isAbsolute(relativeTarget)) {
 			errors.push(`${filePath}: relative link escapes the meta skill directory: ${target}`);

--- a/cli/packages/coding-agent/src/disco/skills/prepare-paper-recovery-env/scripts/probe_runtime.py
+++ b/cli/packages/coding-agent/src/disco/skills/prepare-paper-recovery-env/scripts/probe_runtime.py
@@ -732,7 +732,7 @@ def benchmark_probe(args: argparse.Namespace, logs_dir: Path, command_log: list[
             result["blockers"].append("snapshot resource files are missing: " + ", ".join(missing))
         if not resource_relpaths:
             result["blockers"].append("no benchmark resource files were requested for snapshot")
-        snapshot_dir = Path(args.attempt_dir).expanduser().resolve() / "environment" / "benchmark_sources" / f"{args.benchmark_name}_snapshot"
+        snapshot_dir = Path(args.attempt_dir).expanduser().resolve() / "environment" / "benchmark_sources" / f"{safe_name(args.benchmark_name, 'benchmark')}_snapshot"
         result["snapshot_dir"] = str(snapshot_dir.resolve())
         result["resource_files"] = snapshot_files(resources, snapshot_dir)
     return result

--- a/cli/packages/coding-agent/src/disco/skills/prepare-paper-recovery-env/tests/test_probe_runtime.py
+++ b/cli/packages/coding-agent/src/disco/skills/prepare-paper-recovery-env/tests/test_probe_runtime.py
@@ -212,3 +212,27 @@ def test_probe_runtime_attempts_isolated_env_when_mutation_allowed():
         assert setup["strategy"] == "isolated_environment_repair"
         assert "create_isolated_venv" in labels
         assert "pip_install_definitely_missing_distiller_probe_pkg" in labels
+
+
+def test_benchmark_probe_sanitizes_snapshot_dir():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        repo = root / "repo"
+        repo.mkdir()
+        (repo / "README.md").write_text("benchmark", encoding="utf-8")
+
+        class Args:
+            attempt_dir = str(root / "attempt")
+            benchmark_name = "../../evil"
+            benchmark_url = ""
+            fresh_clone_dir = ""
+            attempt_fresh_clone = False
+            reuse_benchmark_path = str(repo)
+            resource_file = ["README.md"]
+            network_timeout = 1
+            command_timeout = 1
+
+        result = benchmark_probe(Args(), root / "attempt/environment/logs", command_log=[])
+        expected_parent = (root / "attempt").resolve() / "environment" / "benchmark_sources"
+        assert Path(result["snapshot_dir"]).resolve().parent == expected_parent.resolve()
+        assert ".." not in Path(result["snapshot_dir"]).parts

--- a/cli/packages/coding-agent/src/disco/skills/verify-repo-skill/scripts/import_repo_skill.mjs
+++ b/cli/packages/coding-agent/src/disco/skills/verify-repo-skill/scripts/import_repo_skill.mjs
@@ -28,7 +28,7 @@ function defaultAgentDir() {
 }
 
 function expandHome(value) {
-	return value.replace(/^~(?=$|[\/])/, os.homedir());
+	return value.replace(/^~(?=$|[\\/])/, os.homedir());
 }
 
 function pathExists(filePath) {


### PR DESCRIPTION
Three narrow fixes, each aligning a site with its existing in-repo sibling pattern. No new dependencies, backward compatible for legitimate inputs. Upstream provenance manifest refreshed; --check passes. Model/provider/reasoning: N/A (manual patch, no LLM generation). Verification: node --check on both .mjs files; py_compile on probe_runtime.py; new pytest case fails-before/passes-after; 2 unrelated Windows venv-teardown failures pre-exist on clean tree; full vitest suite not run here (no node_modules). Known gaps: none introduced.